### PR TITLE
Change gem's home url public

### DIFF
--- a/lib/ssl_diagnostics/version.rb
+++ b/lib/ssl_diagnostics/version.rb
@@ -1,9 +1,11 @@
 module SslDiagnostics
-  VERSION = '0.0.1'
+  VERSION = '0.1.0'
 end
 
 # History
 # =======
 #
 # 0.0.1: First version
+#
+# 0.1.0: Updates public url
 # 

--- a/ssl_diagnostics.gemspec
+++ b/ssl_diagnostics.gemspec
@@ -9,12 +9,9 @@ Gem::Specification.new do |s|
   s.version     = SslDiagnostics::VERSION
   s.authors     = ["Rob Nichols"]
   s.email       = ["rob@undervale.co.uk"]
-  s.homepage    = "https://git.warwickshire.gov.uk/ssl_diagnostics"
+  s.homepage    = "https://github.com/warwickshire/ssl_diagnostics"
   s.summary     = "SSL Diagnostic tool"
   s.description = "Wrapper for Mislav Marohnić's SSL Doctor"
   s.license     = "MIT-LICENSE"
   s.files = Dir["lib/**/*"] + Dir["tasks/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
-
-
-
 end


### PR DESCRIPTION
The current home page points at the internal WCC git repository.
